### PR TITLE
Renamed `display_` to `draw_` to better reflect its mutating nature

### DIFF
--- a/src/10-ResultType.md
+++ b/src/10-ResultType.md
@@ -1,6 +1,6 @@
 # Error Handling with the Result Type
 
-Check the warnings in the terminal output. What does it say about the Result Type in `fn display_rectangle()`?
+Check the warnings in the terminal output. What does it say about the Result Type in `fn draw_rectangle()`?
 
 1. Check the `sdl2` documentation for the return value of the `fill_rect()` method. Research in the `std` documentation how to use this value.
 

--- a/src/11-OwnershipBorrowing.md
+++ b/src/11-OwnershipBorrowing.md
@@ -59,11 +59,11 @@ But there are two restrictions:
 * There can only be one mutable reference to a value!
 * A value can not be borrowed mutable and immutable!
 
-Take another look at `fn display_frame`. Where are borrowed values?
+Take another look at `fn draw_frame`. Where are borrowed values?
 
 ```rust
 
-fn display_frame (
+fn draw_frame (
     renderer: &mut Canvas<Window>,
     canvas_width: &i32,
     canvas_height: &i32,

--- a/src/12-dereferencing.md
+++ b/src/12-dereferencing.md
@@ -3,7 +3,7 @@
 Looking at the function from our game, we can now explain almost all the peculiar signs. One is missing... try running your program without the `*`s.
 
 ```rust
-fn display_rectangle (
+fn draw_rectangle (
     renderer: &mut Canvas<Window>,
     canvas_width: &u32,
     canvas_height: &u32,

--- a/src/16-frames.md
+++ b/src/16-frames.md
@@ -4,10 +4,10 @@ For each frame, the grid is drawn by displaying each single cell as a rectangle.
 
 In `fn main()`, right after we defined the variables for rows and columns, define a variable for `cell_width` and calculate its value.
 
-`fn display_cell` converts row column values of a single Cell into x and y pixels and draws a rectangle in the specified color at the specified coordinate.
+`fn draw_cell` converts row column values of a single Cell into x and y pixels and draws a rectangle in the specified color at the specified coordinate.
 
 ```rust
-pub fn display_cell(
+pub fn draw_cell(
     renderer: &mut Canvas<Window>,
     row: u32,
     col: u32,
@@ -40,10 +40,10 @@ pub fn display_cell(
 }
 ```
 
-`fn display_frame` displays the whole grid by repeatedly calling `fn display_cell` on every cell in the grid.
+`fn draw_frame` displays the whole grid by repeatedly calling `fn draw_cell` on every cell in the grid.
 
 ```rust
-pub fn display_frame(
+pub fn draw_frame(
     renderer: &mut Canvas<Window>,
     grid: &Grid,
     nx_cells: &u32,
@@ -57,19 +57,19 @@ pub fn display_frame(
 
     for row in 0..*ny_cells {
         for column in 0..*nx_cells {
-            display_cell(renderer, row, column, &grid, &cell_width)
+            draw_cell(renderer, row, column, &grid, &cell_width)
         }
     }
     renderer.present();
 }
 ```
 
-Add both of these functions to your program. Discuss, how the compare to `fn display_rectangle`. Then delete `fn display_rectangle`, as is not needed anymore.
+Add both of these functions to your program. Discuss, how the compare to `fn draw_rectangle`. Then delete `fn draw_rectangle`, as is not needed anymore.
 
-Substitute the line that calls `fn display_rectangle` with the following line:
+Substitute the line that calls `fn draw_rectangle` with the following line:
 
 ```rust
-lib::display_frame(&mut canvas, &grid, &columns, &rows, &cell_width);
+lib::draw_frame(&mut canvas, &grid, &columns, &rows, &cell_width);
 ```
 
 Run the program! Enjoy!

--- a/src/18-solution.md
+++ b/src/18-solution.md
@@ -106,5 +106,5 @@ for event in events.poll_iter() {
 
 snake = snake::snake_moves(&mut snake, direction);
 grid = snake::draw_grid_with_snake(grid, &snake);
-lib::display_frame(&mut canvas, &grid, &columns, &rows, &cell_width);
+lib::draw_frame(&mut canvas, &grid, &columns, &rows, &cell_width);
 ```

--- a/src/9-frames.md
+++ b/src/9-frames.md
@@ -22,7 +22,7 @@ Add the following function to your program.
 
 ```rust
 
-fn display_rectangle (
+fn draw_rectangle (
     renderer: &mut Canvas<Window>,
     canvas_width: &u32,
     canvas_height: &u32,


### PR DESCRIPTION
`fn draw_frame` takes `Canvas<Window>` by mutable borrow.
The name "display" however does not make it clear that the canvas will be mutated.
For "drawing" however it should be clear that "paint" is about to be applied to the canvas, thus mutating it.

Note: Marking this as a draft as merging it (and going live) while today's RustBridge is still ongoing would probably do more harm than good in the short term.