### PR TITLE
Unified inconsistent naming of `canvas`/`renderer` to `canvas`, to match the type

### DIFF
--- a/src/11-OwnershipBorrowing.md
+++ b/src/11-OwnershipBorrowing.md
@@ -64,26 +64,25 @@ Take another look at `fn display_frame`. Where are borrowed values?
 ```rust
 
 fn display_frame (
-    renderer: &mut Canvas<Window>,
+    canvas: &mut Canvas<Window>,
     canvas_width: &i32,
     canvas_height: &i32,
-
 ) {
     let red: u8 = rand::random();
     let green: u8 = rand::random();
     let blue: u8 = rand::random();
 
-    renderer.clear();
+    canvas.clear();
 
     let drawing_color = Color::RGB(red, green, blue);
-    renderer.set_draw_color(drawing_color);
+    canvas.set_draw_color(drawing_color);
 
     let square_definition = Rect::new(0, 0, *canvas_width as u32, *canvas_height as u32);
-    let square = renderer.fill_rect(square_definition);
+    let square = canvas.fill_rect(square_definition);
     match square {
         Ok(()) => {}
         Err(error) => println!("{}", error),
     }
-    renderer.present();
+    canvas.present();
 }
 ```

--- a/src/11-SolutionUsingResult.md
+++ b/src/11-SolutionUsingResult.md
@@ -1,7 +1,7 @@
 # Solution for Using the ResultType
 
 ```rust
-let square = renderer.fill_rect(square_definition);
+let square = canvas.fill_rect(square_definition);
 match square {
     Ok(()) => {}
     Err(error) => println!("{}", error),

--- a/src/12-dereferencing.md
+++ b/src/12-dereferencing.md
@@ -4,7 +4,7 @@ Looking at the function from our game, we can now explain almost all the peculia
 
 ```rust
 fn display_rectangle (
-    renderer: &mut Canvas<Window>,
+    canvas: &mut Canvas<Window>,
     canvas_width: &u32,
     canvas_height: &u32,
 
@@ -13,19 +13,19 @@ fn display_rectangle (
     let green: u8 = rand::random();
     let blue: u8 = rand::random();
 
-    renderer.clear();
+    canvas.clear();
 
     let drawing_color = Color::RGB(red, green, blue);
-    renderer.set_draw_color(drawing_color);
+    canvas.set_draw_color(drawing_color);
 
     // let square_definition = Rect::new(0, 0, *canvas_width, *canvas_height);
     let square_definition = Rect::new(0, 0, canvas_width, canvas_height);
-    let square = renderer.fill_rect(square_definition);
+    let square = canvas.fill_rect(square_definition);
     match square {
         Ok(()) => {}
         Err(error) => println!("{}", error),
 
-    renderer.present();
+    canvas.present();
 }
 ```
 

--- a/src/16-frames.md
+++ b/src/16-frames.md
@@ -8,7 +8,7 @@ In `fn main()`, right after we defined the variables for rows and columns, defin
 
 ```rust
 pub fn display_cell(
-    renderer: &mut Canvas<Window>,
+    canvas: &mut Canvas<Window>,
     row: u32,
     col: u32,
     grid_data: &Grid,
@@ -31,8 +31,8 @@ pub fn display_cell(
 
     let drawing_color = Color::RGB(red, green, blue);
 
-    renderer.set_draw_color(drawing_color);
-    let square = renderer.fill_rect(Rect::new(x, y, *cell_width, *cell_height));
+    canvas.set_draw_color(drawing_color);
+    let square = canvas.fill_rect(Rect::new(x, y, *cell_width, *cell_height));
     match square {
         Ok(()) => {}
         Err(error) => println!("{}", error),
@@ -44,7 +44,7 @@ pub fn display_cell(
 
 ```rust
 pub fn display_frame(
-    renderer: &mut Canvas<Window>,
+    canvas: &mut Canvas<Window>,
     grid: &Grid,
     nx_cells: &u32,
     ny_cells: &u32,
@@ -52,15 +52,15 @@ pub fn display_frame(
 ) {
 
 
-    renderer.set_draw_color(Color::RGB(0, 0, 0));
-    renderer.clear();
+    canvas.set_draw_color(Color::RGB(0, 0, 0));
+    canvas.clear();
 
     for row in 0..*ny_cells {
         for column in 0..*nx_cells {
-            display_cell(renderer, row, column, &grid, &cell_width)
+            display_cell(canvas, row, column, &grid, &cell_width)
         }
     }
-    renderer.present();
+    canvas.present();
 }
 ```
 

--- a/src/9-frames.md
+++ b/src/9-frames.md
@@ -23,7 +23,7 @@ Add the following function to your program.
 ```rust
 
 fn display_rectangle (
-    renderer: &mut Canvas<Window>,
+    canvas: &mut Canvas<Window>,
     canvas_width: &u32,
     canvas_height: &u32,
 
@@ -32,23 +32,23 @@ fn display_rectangle (
     let green: u8 = rand::random();
     let blue: u8 = rand::random();
 
-    renderer.clear();
+    canvas.clear();
 
     let drawing_color = Color::RGB(red, green, blue);
-    renderer.set_draw_color(drawing_color);
+    canvas.set_draw_color(drawing_color);
 
     let square_definition = Rect::new(0, 0, *canvas_width, *canvas_height);
-    renderer.fill_rect(square_definition);
+    canvas.fill_rect(square_definition);
 
-    renderer.present();
+    canvas.present();
 }
 
 ```
 
 The function takes the canvas, as well as the canvas width and height as arguments. It does not return a value. In the body of the function, the variables red, green and blue are assigned random `u8` numbers.
-The `clear()` method is called on the renderer, this clears the canvas. When, like in our case, the entire canvas is drawn over, this does not really matter, but it's a good habit, to think of this.
+The `clear()` method is called on the canvas, this clears the canvas. When, like in our case, the entire canvas is drawn over, this does not really matter, but it's a good habit, to think of this.
 Then, the drawing color is defined. We use a function that is provided by `sdl2`, the function takes in three `u8` values and returns a color.
-The method `set_draw_color()` is called on the renderer, with `drawing_color` as argument.
+The method `set_draw_color()` is called on the canvas, with `drawing_color` as argument.
 
 We create a new rectangle with it's minimum and maximum x and y values as arguments and bind it to the variable `square_definition`. This variable is then passed to the method `fill_rect()`. Our square is rendered and put into the back buffer.
 


### PR DESCRIPTION
There was quite a bit of confusion about where the mysterious `renderer` value was supposed to be coming from. Turns out it's just a canvas. Renaming `renderer` to `canvas` should make this more clear.

Note: Marking this as a draft as merging it (and going live) while today's RustBridge is still ongoing would probably do more harm than good in the short term.