### PR TITLE
Improve `fn display_rectangle`

### DIFF
--- a/src/10-ResultType.md
+++ b/src/10-ResultType.md
@@ -1,6 +1,6 @@
 # Error Handling with the Result Type
 
-Check the warnings in the terminal output. What does it say about the Result Type in `fn display_rectangle()`?
+Check the warnings in the terminal output. What does it say about the Result Type in `fn display_frame()`?
 
 1. Check the `sdl2` documentation for the return value of the `fill_rect()` method. Research in the `std` documentation how to use this value.
 

--- a/src/11-OwnershipBorrowing.md
+++ b/src/11-OwnershipBorrowing.md
@@ -65,8 +65,8 @@ Take another look at `fn display_frame`. Where are borrowed values?
 
 fn display_frame (
     renderer: &mut Canvas<Window>,
-    canvas_width: &i32,
-    canvas_height: &i32,
+    canvas_width: &u32,
+    canvas_height: &u32,
 ) {
     let red: u8 = rand::random();
     let green: u8 = rand::random();
@@ -77,7 +77,7 @@ fn display_frame (
     let drawing_color = Color::RGB(red, green, blue);
     renderer.set_draw_color(drawing_color);
 
-    let square_definition = Rect::new(0, 0, *canvas_width as u32, *canvas_height as u32);
+    let square_definition = Rect::new(0, 0, *canvas_width, *canvas_height);
     let square = renderer.fill_rect(square_definition);
     match square {
         Ok(()) => {}

--- a/src/11-OwnershipBorrowing.md
+++ b/src/11-OwnershipBorrowing.md
@@ -67,7 +67,6 @@ fn display_frame (
     renderer: &mut Canvas<Window>,
     canvas_width: &i32,
     canvas_height: &i32,
-
 ) {
     let red: u8 = rand::random();
     let green: u8 = rand::random();

--- a/src/12-dereferencing.md
+++ b/src/12-dereferencing.md
@@ -7,7 +7,6 @@ fn display_frame (
     renderer: &mut Canvas<Window>,
     canvas_width: &u32,
     canvas_height: &u32,
-
 ) {
     let red: u8 = rand::random();
     let green: u8 = rand::random();

--- a/src/12-dereferencing.md
+++ b/src/12-dereferencing.md
@@ -3,7 +3,7 @@
 Looking at the function from our game, we can now explain almost all the peculiar signs. One is missing... try running your program without the `*`s.
 
 ```rust
-fn display_rectangle (
+fn display_frame (
     renderer: &mut Canvas<Window>,
     canvas_width: &u32,
     canvas_height: &u32,

--- a/src/16-frames.md
+++ b/src/16-frames.md
@@ -64,9 +64,9 @@ pub fn display_frame(
 }
 ```
 
-Add both of these functions to your program. Discuss, how the compare to `fn display_rectangle`. Then delete `fn display_rectangle`, as is not needed anymore.
+Add both of these functions to your program. Discuss, how the compare to `fn display_frame`. Then delete `fn display_frame`, as is not needed anymore.
 
-Substitute the line that calls `fn display_rectangle` with the following line:
+Substitute the line that calls `fn display_frame` with the following line:
 
 ```rust
 lib::display_frame(&mut canvas, &grid, &columns, &rows, &cell_width);

--- a/src/9-frames.md
+++ b/src/9-frames.md
@@ -22,7 +22,7 @@ Add the following function to your program.
 
 ```rust
 
-fn display_rectangle (
+fn display_frame (
     renderer: &mut Canvas<Window>,
     canvas_width: &u32,
     canvas_height: &u32,

--- a/src/9-frames.md
+++ b/src/9-frames.md
@@ -26,7 +26,6 @@ fn display_frame (
     renderer: &mut Canvas<Window>,
     canvas_width: &u32,
     canvas_height: &u32,
-
 ) {
     let red: u8 = rand::random();
     let green: u8 = rand::random();


### PR DESCRIPTION
The snippets of `fn display_rectangle`/`fn display_frame` are somewhat inconsistent:

- sometime the function is called  `fn display_rectangle`, sometimes `fn display_frame`.
- sometimes the function takes `&u32` arguments, sometimes its `&i32`, which then are cast back to u32, inside.

Note: Marking this as a draft as merging it (and going live) while today's RustBridge is still ongoing would probably do more harm than good in the short term.
